### PR TITLE
Add author and editor lists

### DIFF
--- a/_drafts/YYYYY-MM-DD-template.md
+++ b/_drafts/YYYYY-MM-DD-template.md
@@ -3,6 +3,11 @@ layout: post
 title:  "March - This Month in Luanti (02)"
 description: >
   Mapgen Work, Main Menu Redesign
+authors: [JohnDoe] # Required, must be an array
+editors: [Bobby, Sue] # Optional, must be an array
+contributors: # Optional, must be an array
+  - BillPreston6
+  - TedTheodore9
 image: /static/blog/2022_March/Sunrays.png
 tags:
   - last_month

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,41 +13,43 @@ layout: default
 		<div class="container">
 			<h1 class="title">{{ page.title }}</h1>
 			<p class="subtitle">
-				{%- if page.authors -%}
+				{% if page.authors %}
 					Written by
-					{%- for author in page.authors -%}
-						{%- assign data = site.data.authors[author] -%}
-						{%- if data -%}
-							<a href="{{ data.url }}">
-								{{author -}}
-							</a>
-						{%- else -%}
-							{{ author -}}
-						{%- endif -%}
+					{%- for author in page.authors %}
+						{%- if forloop.last == true %}
+                            {%- if forloop.index > 2 %},{%- endif %}
+                            {% if forloop.index > 1 %}and{% endif %}
+                        {%- else %}
+                            {%- if forloop.index > 1 %},{%- endif %}
+						{%- endif %}
 
-						{%- if forloop.last == false -%}
-							,
-						{%- endif -%}
-					{%- endfor -%}
-				{%- endif -%}
+						{% assign data = site.data.authors[author] %}
+						{%- if data %}
+							<a href="{{ data.url }}">{{- author}}</a>
+						{%- else %}
+							{{- author}}
+						{%- endif %}
+					{%- endfor %}
+				{% endif %}
 
-				{%- if page.editors -%}
+                {% if page.editors %}
 					<br>Edited by
-					{%- for editor in page.editors -%}
-						{% assign data = site.data.authors[editor] %}
-						{% if data %}
-							<a href="{{ data.url }}">
-								{{editor -}}
-							</a>
-						{% else %}
-							{{ editor -}}
-						{% endif %}
+					{%- for editor in page.editors %}
+						{%- if forloop.last == true %}
+                            {%- if forloop.index > 2 %},{%- endif %}
+                            {% if forloop.index > 1 %}and{% endif %}
+                        {%- else %}
+                            {%- if forloop.index > 1 %},{%- endif %}
+						{%- endif %}
 
-						{%- if forloop.last == false -%}
-							,
-						{%- endif -%}
-					{%- endfor -%}
-				{%- endif -%}
+						{% assign data = site.data.authors[editor] %}
+						{%- if data %}
+							<a href="{{ data.url }}">{{- editor}}</a>
+						{%- else %}
+							{{- editor}}
+						{%- endif %}
+					{%- endfor %}
+				{% endif %}
 			</p>
 			<p>
 				{% for tagname in page.tags %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -114,9 +114,26 @@ layout: default
 			<p class="mt-6 has-text-grey">
 				{% if page.contributors %}
 					Thanks to our post contributors this month:
-					{{ page.contributors | join: ", " }}.
+                    {%- for contributor in page.contributors %}
+                        {%- if forloop.last == true %}
+                            {%- if forloop.index > 2 %},{%- endif %}
+                            {% if forloop.index > 1 %}and{% endif %}
+                        {%- else %}
+                            {%- if forloop.index > 1 %},{%- endif %}
+                        {%- endif %}
+
+                        {% assign data = site.data.authors[contributor] %}
+                        {%- if data %}
+                            <a href="{{ data.url }}">{{- contributor}}</a>
+                        {%- else %}
+                            {{- contributor}}
+                        {%- endif %}
+                    {%- endfor %}
 				{% endif %}
 				{% if page.image_credit %}
+                    {% if page.contributors  %}
+                        <br>
+                    {% endif %}
 					Cover image by {{ page.image_credit }}.
 				{% endif %}
 			</p>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,19 +12,43 @@ layout: default
 	<div class="hero-body">
 		<div class="container">
 			<h1 class="title">{{ page.title }}</h1>
-			{% if page.author %}
-				<p class="subtitle">
-					By
-					{% assign author = site.data.authors[page.author] %}
-					{% if author %}
-						<a href="{{ author.url }}">
-							{{ page.author }}
-						</a>
-					{% else %}
-						{{ page.author }}
-					{% endif %}
-				</p>
-			{% endif %}
+			<p class="subtitle">
+				{%- if page.authors -%}
+					Written by
+					{%- for author in page.authors -%}
+						{%- assign data = site.data.authors[author] -%}
+						{%- if data -%}
+							<a href="{{ data.url }}">
+								{{author -}}
+							</a>
+						{%- else -%}
+							{{ author -}}
+						{%- endif -%}
+
+						{%- if forloop.last == false -%}
+							,
+						{%- endif -%}
+					{%- endfor -%}
+				{%- endif -%}
+
+				{%- if page.editors -%}
+					<br>Edited by
+					{%- for editor in page.editors -%}
+						{% assign data = site.data.authors[editor] %}
+						{% if data %}
+							<a href="{{ data.url }}">
+								{{editor -}}
+							</a>
+						{% else %}
+							{{ editor -}}
+						{% endif %}
+
+						{%- if forloop.last == false -%}
+							,
+						{%- endif -%}
+					{%- endfor -%}
+				{%- endif -%}
+			</p>
 			<p>
 				{% for tagname in page.tags %}
 					{% assign tag = site.my_tags | where: "slug", tagname | first %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -17,10 +17,10 @@ layout: default
 					Written by
 					{%- for author in page.authors %}
 						{%- if forloop.last == true %}
-                            {%- if forloop.index > 2 %},{%- endif %}
-                            {% if forloop.index > 1 %}and{% endif %}
-                        {%- else %}
-                            {%- if forloop.index > 1 %},{%- endif %}
+							{%- if forloop.index > 2 %},{%- endif %}
+							{% if forloop.index > 1 %}and{% endif %}
+						{%- else %}
+							{%- if forloop.index > 1 %},{%- endif %}
 						{%- endif %}
 
 						{% assign data = site.data.authors[author] %}
@@ -32,14 +32,14 @@ layout: default
 					{%- endfor %}
 				{% endif %}
 
-                {% if page.editors %}
+				{% if page.editors %}
 					<br>Edited by
 					{%- for editor in page.editors %}
 						{%- if forloop.last == true %}
-                            {%- if forloop.index > 2 %},{%- endif %}
-                            {% if forloop.index > 1 %}and{% endif %}
-                        {%- else %}
-                            {%- if forloop.index > 1 %},{%- endif %}
+							{%- if forloop.index > 2 %},{%- endif %}
+							{% if forloop.index > 1 %}and{% endif %}
+						{%- else %}
+							{%- if forloop.index > 1 %},{%- endif %}
 						{%- endif %}
 
 						{% assign data = site.data.authors[editor] %}
@@ -114,26 +114,26 @@ layout: default
 			<p class="mt-6 has-text-grey">
 				{% if page.contributors %}
 					Thanks to our post contributors this month:
-                    {%- for contributor in page.contributors %}
-                        {%- if forloop.last == true %}
-                            {%- if forloop.index > 2 %},{%- endif %}
-                            {% if forloop.index > 1 %}and{% endif %}
-                        {%- else %}
-                            {%- if forloop.index > 1 %},{%- endif %}
-                        {%- endif %}
+					{%- for contributor in page.contributors %}
+						{%- if forloop.last == true %}
+							{%- if forloop.index > 2 %},{%- endif %}
+							{% if forloop.index > 1 %}and{% endif %}
+						{%- else %}
+							{%- if forloop.index > 1 %},{%- endif %}
+						{%- endif %}
 
-                        {% assign data = site.data.authors[contributor] %}
-                        {%- if data %}
-                            <a href="{{ data.url }}">{{- contributor}}</a>
-                        {%- else %}
-                            {{- contributor}}
-                        {%- endif %}
-                    {%- endfor %}
+						{% assign data = site.data.authors[contributor] %}
+						{%- if data %}
+							<a href="{{ data.url }}">{{- contributor}}</a>
+						{%- else %}
+							{{- contributor}}
+						{%- endif %}
+					{%- endfor %}
 				{% endif %}
 				{% if page.image_credit %}
-                    {% if page.contributors  %}
-                        <br>
-                    {% endif %}
+					{% if page.contributors  %}
+						<br>
+					{% endif %}
 					Cover image by {{ page.image_credit }}.
 				{% endif %}
 			</p>

--- a/_posts/2022-01-22-Welcome.md
+++ b/_posts/2022-01-22-Welcome.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Welcome to the new Minetest Blog
-author: MisterE
+authors: [MisterE]
 image: /static/blog/default_hero.png
 tags:
   - blog
@@ -13,6 +13,8 @@ forum_topic: https://forum.luanti.org/viewtopic.php?f=3&t=27713
 
 
 A Blog is a great way for a project to share updates and generate excitement for new featues among its community. Thats why we are starting a new blog for minetest! This will be a great way to stay up-to-date with the diverse parts of the community. Blog content will be solicited from community members, for Engine development updates, Mods, Games, Builds, Art, Servers and anything minetest related. Yes, this will include shills for people's own projects, but they need an excuse such as a major update, great new feature, or event. See [Contributing Guidelines](/about/)
+
+<!-- more -->
 
 As for the release schedule, that depends on time available for the editors to review content, the number of active editors, and the amount of content submitted. We may aim for a weekly release schedule, though bi-weekly or monthly seems more sustainable. We need you to be an editor; if you have the time and the desire to help us edit this blog, please contact MisterE on the Forums.
 

--- a/_posts/2022-02-26-February.md
+++ b/_posts/2022-02-26-February.md
@@ -1,9 +1,15 @@
 ---
 layout: post
-title:  "February - This Month in Minetest (01)"
-author: MisterE
-contributors: ["rubenwardy", "Talas", "ElCeejo", "Bastrubun", "ExeVirus",
-    "Oakenshield", "MisterE", "Apercy"]
+title: "February - This Month in Minetest (01)"
+authors: [MisterE]
+contributors:
+    - rubenwardy
+    - Talas
+    - ElCeejo
+    - Bastrubun
+    - ExeVirus
+    - Oakenshield
+    - Apercy
 description: >
   A new Minetest version and new content
 image: /static/blog/2022_February/pig.png

--- a/_posts/2022-03-27-March.md
+++ b/_posts/2022-03-27-March.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "March - This Month in Minetest (02)"
-author: MisterE
+authors: [MisterE]
 description: >
   Mapgen Work, Main Menu Redesign
 image: /static/blog/2022_March/Sunrays.png

--- a/_posts/2022-05-08-April.md
+++ b/_posts/2022-05-08-April.md
@@ -1,7 +1,12 @@
 ---
 layout: post
 title:  "April - This Month in Minetest (03)"
-contributors: ["rubenwardy", "MisterE", "Warr1024", "dew", "Ineva"]
+authors: [rubenwardy]
+contributors:
+  - MisterE
+  - Warr1024
+  - dew
+  - Ineva
 description: >
   This month, engine development picks up with regular meetings,
   NodeCore gets a 24/7 livestream, and the Minetest Blog is now official!

--- a/_posts/2022-06-05-May.md
+++ b/_posts/2022-06-05-May.md
@@ -1,7 +1,10 @@
 ---
 layout: post
 title:  "May - This Month in Minetest (04)"
-contributors: ["MisterE", "rubenwardy"]
+authors: [MisterE]
+editors: [rubenwardy]
+contributors:
+  - ExeVirus
 description: >
   This month, Minetest 5.5.1 was released, we reached less than 90 PRs and 1000
   issues, and there's been big improvements to performance, rendering and

--- a/_posts/2022-07-07-June.md
+++ b/_posts/2022-07-07-June.md
@@ -1,9 +1,9 @@
 ---
 layout: post
 title:  "June - This Month in Minetest (05)"
+authors: [rubenwardy]
 contributors:
   - MisterE
-  - rubenwardy
   - NathanS
   - ExeVirus
   - kilbith

--- a/_posts/2022-08-04-5.6.0-released.md
+++ b/_posts/2022-08-04-5.6.0-released.md
@@ -1,8 +1,8 @@
 ---
 layout: post
 title: "Minetest 5.6.0 released!"
-author: rubenwardy
-contributors: ["Ronoaldo"]
+authors: [rubenwardy]
+contributors: [Ronoaldo, MisterE]
 description: >-
   Minetest 5.6.0 has been released with dynamic shadows, improvements to
   mod management, a clearer player registration process, and more!

--- a/_posts/2022-08-12-July.md
+++ b/_posts/2022-08-12-July.md
@@ -1,9 +1,8 @@
 ---
 layout: post
 title:  "July - This Month in Minetest (06)"
+authors: [rubenwardy, MisterE]
 contributors:
-  - MisterE
-  - rubenwardy
   - chrbinder
   - Lemente
   - komodo

--- a/_posts/2022-09-13-August.md
+++ b/_posts/2022-09-13-August.md
@@ -1,9 +1,9 @@
 ---
 layout: post
 title: "August - This Month in Minetest (07)"
+authors: [MisterE]
+editors: [rubenwardy]
 contributors:
-  - MisterE
-  - rubenwardy
   - Elceejo
   - TheMalaysianDude
   - Ineva

--- a/_posts/2022-10-14-September.md
+++ b/_posts/2022-10-14-September.md
@@ -1,9 +1,9 @@
 ---
 layout: post
 title: "September - This Month in Minetest (08)"
+authors: [MisterE]
+editors: [rubenwardy]
 contributors:
-  - MisterE
-  - rubenwardy
   - Peppermint Patty
   - Warr1024
   - BuckarooBanzai

--- a/_posts/2022-12-10-November.md
+++ b/_posts/2022-12-10-November.md
@@ -1,9 +1,9 @@
 ---
 layout: post
 title: "November - Last Month in Minetest (09)"
+authors: [MisterE]
+editors: [rubenwardy]
 contributors:
-  - MisterE
-  - rubenwardy
   - Apercy
   - Komodo
   - Zughy

--- a/_posts/2023-02-16-January.md
+++ b/_posts/2023-02-16-January.md
@@ -1,9 +1,9 @@
 ---
 layout: post
 title: "January - Last Month in Minetest (10)"
+authors: [MisterE]
+editors: [rubenwardy]
 contributors:
-  - MisterE
-  - rubenwardy
   - Warr1024
   - Zughy
   - Phii

--- a/_posts/2023-03-12-February.md
+++ b/_posts/2023-03-12-February.md
@@ -1,8 +1,8 @@
 ---
 layout: post
 title: "February - Last Month in Minetest (11)"
+authors: [MisterE]
 contributors:
-  - MisterE
   - rubenwardy
   - Zughy
   - Wuzzy

--- a/_posts/2023-04-08-5.7.0-released.md
+++ b/_posts/2023-04-08-5.7.0-released.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Minetest 5.7.0 released!"
-author: rubenwardy
+authors: [rubenwardy]
 contributors:
   - GreenXenith
   - Extex

--- a/_posts/2023-04-16-March.md
+++ b/_posts/2023-04-16-March.md
@@ -1,9 +1,8 @@
 ---
 layout: post
 title: "March - Last Month in Minetest (12)"
+authors: [MisterE, rubenwardy]
 contributors:
-  - MisterE
-  - rubenwardy
   - appgurueu
   - Sakel
   - Extex

--- a/_posts/2023-05-23-April.md
+++ b/_posts/2023-05-23-April.md
@@ -1,15 +1,16 @@
 ---
 layout: post
 title: "April - Last Month in Minetest (13)"
+authors: [MisterE]
 contributors:
-  - MisterE
-  - rubenwardy
   - Lemente
   - Sakel
   - Apercy
   - Ineva
   - Notsowow
   - Andrey01
+  - rubenwardy
+  - Desour
 description: >
   After the release of Minetest 5.7.0 in April, there were some improvements to
   the api for craft items. MineClone2 got the "Safe and Sound" update, there were

--- a/_posts/2023-07-30-MayJuneJuly.md
+++ b/_posts/2023-07-30-MayJuneJuly.md
@@ -1,14 +1,14 @@
 ---
 layout: post
 title: "May, June, and July in Minetest (14)"
+authors: [MisterE]
+editors: [GreenXenith]
 contributors:
-  - MisterE
   - Rubenwardy
   - EmptyStar
   - Athozus
   - Lemente
   - CodeScratcher
-  - GreenXenith
 description: >
   Work on the 5.8 release continues with some exciting new engine improvements, a classic game makes its way to
   ContentDB, and the use of Minetest in education was explored.

--- a/_posts/2023-10-17-AugustSeptember.md
+++ b/_posts/2023-10-17-AugustSeptember.md
@@ -4,9 +4,9 @@ title: "August and September in Minetest (15)"
 contributors:
   - 56independent
   - erlehmann
-  - GreenXenith
   - Niklp
   - rubenwardy
+  - MisterE
 authors:
   - GreenXenith
 description: >

--- a/_posts/2023-12-04-5.8.0-released.md
+++ b/_posts/2023-12-04-5.8.0-released.md
@@ -1,9 +1,14 @@
 ---
 layout: post
 title: "Minetest 5.8.0 released!"
-author: rubenwardy
+authors: [rubenwardy]
 contributors:
   - rollerozxa
+  - luatic
+  - grorp
+  - TheShadowOfHassen
+  - srifqi
+  - GreenXenith
 description: >-
   Minetest 5.8.0 has been released with improved onboarding, a new Settings
   GUI, and improved Android controls

--- a/_posts/2024-01-29-January.md
+++ b/_posts/2024-01-29-January.md
@@ -1,9 +1,9 @@
 ---
 layout: post
 title: "October to January in Minetest (16)"
+authors: [MisterE]
+editors: [GreenXenith]
 contributors:
-  - MisterE
-  - GreenXenith
   - rubenwardy
   - Zughy
   - jordan4ibanez
@@ -12,7 +12,8 @@ contributors:
   - BuckarooBanzay
   - jdiego
   - grorp
-  - Luatic
+  - luatic
+  - TheShadowOfHassen
 description: >
   Improvements are made to graphics, the Lua API, and the user interface. We present the winners of the 2023 Game
   Jam along with other cool mods. A new core developer joins the team, and we look forward to FOSDEM 2024!

--- a/_posts/2024-08-12-5.9.0-released.md
+++ b/_posts/2024-08-12-5.9.0-released.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Minetest 5.9.0 released!"
-author: luatic
+authors: [luatic]
 description: >-
   Minetest 5.9.0 has been released with performance improvements for rendering and map generation,
   new graphical effects, and much more.

--- a/_posts/2024-10-13-Introducing-Our-New-Name.md
+++ b/_posts/2024-10-13-Introducing-Our-New-Name.md
@@ -4,10 +4,8 @@ title: "Introducing Our New Name"
 description: >-
   After more than a year of public and internal discussions, we're ready to
   announce our new name!
-contributors:
-  - Zughy
-  - GreenXenith
-  - FreshReplicant
+authors: [Zughy, GreenXenith]
+contributors: [FreshReplicant, grorp]
 image: /static/blog/New_Name/cover.jpg
 image_credit: Zughy
 forum_topic: https://forum.luanti.org/viewtopic.php?t=31048

--- a/_posts/2024-11-10-5.10.0-released.md
+++ b/_posts/2024-11-10-5.10.0-released.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 title: "Luanti 5.10.0 released!"
-author: luatic, grorp, GreenXenith
+authors: [luatic, grorp]
+editors: [GreenXenith]
 description: >-
   Luanti (formerly Minetest) 5.10.0 has been released! Highlights include a content browser redesign, support for the
   modern glTF model format, gettext translation support, new visual effects, an API for per-player objects, usability
@@ -11,6 +12,8 @@ excerpt: >-
   modern glTF model format, gettext translation support, new visual effects, an API for per-player objects, usability
   improvements, and more.
 image: /static/blog/5.10.0/cover.webp
+contributors: [Desour, y5nw, rubenwardy]
+
 image_credit: Gefüllte Taubenbrust
 forum_topic: https://forum.luanti.org/viewtopic.php?p=440491
 tags:

--- a/_posts/2025-02-14-5.11.0-released.md
+++ b/_posts/2025-02-14-5.11.0-released.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Luanti 5.11.0 released!"
-author: GreenXenith
+authors: [GreenXenith]
 description: >-
   Luanti 5.11.0 is landing right on time following our 3-month release schedule! Many new menu features have arrived alongside font overrides, continued model improvements, rendering fixes, and more.
 excerpt: >-


### PR DESCRIPTION
`authors` and `editors` are arrays. Posts should ideally always have at least an `authors` array.

![image](https://github.com/minetest/blog/assets/24834740/f3a3db53-6b31-4e03-baae-aeecaadf35c7)
